### PR TITLE
Update fontmin.js

### DIFF
--- a/tasks/fontmin.js
+++ b/tasks/fontmin.js
@@ -52,7 +52,7 @@ function taskFontmin() {
         let output = ttfToOutput(stripped, type, typeOpts)
 
         // solve dest path, write output
-        let destPath = join(destdir, getOutputFilename(path))
+        let destPath = join(destdir, getOutputFilename(path,type))
         grunt.file.write(destPath, toBuffer(output))
 
         // output information


### PR DESCRIPTION
The code  produce a output file like `xxx.undefined` instead of an expected `.woff`.

This patch should fix the issue
